### PR TITLE
Support AGP 9 example compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.5.2+2
+
+* Declare Kotlin Gradle Plugin 2.2.20 in the example so Flutter does not fall
+  back to an older soon-unsupported Kotlin version.
+* Apply the example app's Kotlin Gradle Plugin only when the host build still
+  needs it, so the same project can be tested with legacy AGP 8 host builds.
+* Add plugin Gradle fallbacks for older Flutter SDKs that do not expose
+  `flutter.compileSdkVersion` to plugin projects.
+* Keep Kotlin JVM target configuration compatible with older supported Flutter
+  SDKs.
 ## 0.5.2+1
 
 * Reorder README sections.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,16 +23,27 @@ if (shouldApplyKotlinGradlePlugin) {
     apply plugin: 'kotlin-android'
 }
 
+// Flutter 3.10 does not expose this extension to plugin library projects.
+def flutterExtension = project.extensions.findByName("flutter")
+def pluginCompileSdk = flutterExtension?.compileSdkVersion ?: 33
+def pluginMinSdk = flutterExtension?.minSdkVersion ?: 16
+
 android {
     if (project.android.hasProperty("namespace")) {
         namespace = "dev.fluttercommunity.android_id"
     }
 
-    compileSdk = flutter.compileSdkVersion
+    compileSdk = pluginCompileSdk
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    if (shouldApplyKotlinGradlePlugin) {
+        kotlinOptions {
+            jvmTarget = "17"
+        }
     }
 
     sourceSets {
@@ -41,7 +52,7 @@ android {
     }
 
     defaultConfig {
-        minSdk = flutter.minSdkVersion
+        minSdk = pluginMinSdk
     }
 
     dependencies {
@@ -62,8 +73,10 @@ android {
     }
 }
 
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+if (!shouldApplyKotlinGradlePlugin) {
+    kotlin {
+        compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+        }
     }
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,8 +1,22 @@
 plugins {
     id "com.android.application"
-    // The Flutter Gradle Plugin must be applied after the Android Gradle plugin.
-    id "dev.flutter.flutter-gradle-plugin"
 }
+
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+boolean hasBuiltInKotlinSupport = agpMajor >= 9
+
+def builtInKotlinProperty = findProperty('android.builtInKotlin')
+boolean isBuiltInKotlinEnabled = builtInKotlinProperty == null ||
+        builtInKotlinProperty.toString().toBoolean()
+
+boolean shouldApplyKotlinGradlePlugin = !hasBuiltInKotlinSupport || !isBuiltInKotlinEnabled
+
+if (shouldApplyKotlinGradlePlugin) {
+    apply plugin: 'org.jetbrains.kotlin.android'
+}
+
+// The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
+apply plugin: "dev.flutter.flutter-gradle-plugin"
 
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file("local.properties")

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -19,6 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "9.1.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.5.2+1"
+    version: "0.5.2+2"
   async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ topics:
   - android
   - native
 
-version: 0.5.2+1
+version: 0.5.2+2
 
 environment:
   sdk: '>=3.0.0 <4.0.0'


### PR DESCRIPTION
## Summary
- declare Kotlin Gradle Plugin 2.2.20 for the example fallback path
- apply Kotlin plugins only when the host does not use AGP 9 built-in Kotlin
- keep plugin Gradle configuration compatible with older supported Flutter hosts
- bump the package to 0.5.2+2

## Validation
- fresh consumer builds on every installed supported Flutter line from 3.10.6 through 3.44.6
- integration tests on Android API 24, 31, 35, 36, and 37
- AGP 9 legacy and built-in Kotlin paths
- Flutter analysis and unit tests